### PR TITLE
fix: null-guard parameter rules JSONPath to prevent crash on null values

### DIFF
--- a/microcks-rules.yaml
+++ b/microcks-rules.yaml
@@ -86,7 +86,7 @@ rules:
     formats:
       - oas3
     severity: warn
-    given: "$..parameters[?(@.required == true)]"
+    given: "$..parameters[?(@ && @.required == true)]"
     then:
       field: examples
       function: truthy
@@ -97,7 +97,7 @@ rules:
     formats:
       - oas3
     severity: info
-    given: "$..parameters[?(@.required != true)]"
+    given: "$..parameters[?(@ && @.required != true)]"
     then:
       field: examples
       function: truthy

--- a/resources/weather-forecast-openapi-nullable.yaml
+++ b/resources/weather-forecast-openapi-nullable.yaml
@@ -1,0 +1,71 @@
+---
+openapi: 3.0.2
+info:
+  title: WeatherForecast API
+  version: 1.0.0
+  description: Regression fixture for parameter rules JSONPath null-safety.
+  license:
+    name: MIT License
+    url: https://opensource.org/licenses/MIT
+  x-microcks:
+    labels:
+      domain: weather-forecast
+      status: GA
+paths:
+  /forecast:
+    get:
+      operationId: GetForecasts
+      summary: Get forecasts
+      description: Get forecasts
+      tags:
+        - forecast
+      x-microcks-operation:
+        delay: 100
+        dispatcher: RANDOM
+      parameters:
+        - name: region
+          in: query
+          required: true
+          schema:
+            type: string
+          examples:
+            north:
+              value: north
+      responses:
+        "200":
+          description: Weather forecasts for the requested region
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Forecast'
+              examples:
+                north:
+                  value:
+                    region: north
+                    temp: -1.5
+                    weather: snowy
+                    visibility: 25
+                    note: null
+tags:
+  - name: forecast
+    description: Forecast related operation
+
+components:
+  schemas:
+    Forecast:
+      type: object
+      properties:
+        region:
+          type: string
+        temp:
+          format: double
+          type: number
+        weather:
+          type: string
+        visibility:
+          format: int32
+          type: integer
+        note:
+          type: string
+          nullable: true
+          example: null

--- a/test/openapi-rules.test.js
+++ b/test/openapi-rules.test.js
@@ -20,7 +20,21 @@ describe('OpenAPI v3', () => {
     const document = retrieveDocument('../../resources/weather-forecast-openapi.yaml')
 
     const results = await spectral.run(document)
-    
+
+    expect(results).toHaveLength(0)
+  })
+
+  // Regression: the parameter rules used recursive JSONPath filters without a
+  // null guard ($..parameters[?(@.required == true)]), which crashed Spectral
+  // with "Cannot read properties of null (reading 'required')" whenever the
+  // document contained a legitimate null somewhere (e.g. `example: null` on a
+  // nullable property). The fixture below has both.
+  test('Nullable example values do not crash parameter rules', async () => {
+    const spectral = await setupSpectral('microcks-rules.yaml')
+    const document = retrieveDocument('../../resources/weather-forecast-openapi-nullable.yaml')
+
+    const results = await spectral.run(document)
+
     expect(results).toHaveLength(0)
   })
 })


### PR DESCRIPTION
Fixes #111.

## Problem

`microcks-examples-in-required-parameter` and `microcks-examples-in-optional-parameter` use recursive JSONPath filters without a null guard, causing Spectral to crash with `Cannot read properties of null (reading 'required')` whenever the linted document contains a legitimate `null` (for example `example: null` on a `nullable: true` property). See #111 for the full repro and stack trace.

The same class of bug existed in Spectral's own ruleset and was fixed in stoplightio/spectral#2638.

## Fix

Add the `@ &&` null guard to both `given` expressions:

```diff
- given: "$..parameters[?(@.required == true)]"
+ given: "$..parameters[?(@ && @.required == true)]"

- given: "$..parameters[?(@.required != true)]"
+ given: "$..parameters[?(@ && @.required != true)]"
```

## Testing

- Added `resources/weather-forecast-openapi-nullable.yaml`: a valid OpenAPI document containing both a `required: true` parameter (so the rule still matches at least one real target) and a `nullable: true` property with `example: null` (the crash trigger).
- Added a Jest case in `test/openapi-rules.test.js` asserting the document produces zero findings.
- Verified locally:
  - On the unpatched ruleset the new test fails with the Nimma crash trace from the issue.
  - With the fix it passes, and all 4 existing tests still pass.